### PR TITLE
Feat/use inp

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,19 @@ const reportPerformance = () => {
   // Logging is not critical for most application,
   // so you can avoid loading this library in initial bundle by using dynamic import.
   import("@openameba/cwv-logger").then(
-    ({ reportCLS, reportFID, reportLCP, reportTTFB }) => {
+    ({ reportCLS, reportFID, reportLCP, reportTTFB, reportINP }) => {
       reportCLS(handleReport);
       reportFID(handleReport);
       reportLCP(handleReport);
       reportTTFB(handleReport);
+      /**
+       * reportINP has option in second argument.
+       * @see https://github.com/GoogleChrome/web-vitals/tree/next
+       */
+      reportINP(handleReport, {
+        reportAllChanges: false, // or true
+        durationThreshold: 40, // or number
+      });
     }
   );
 };
@@ -53,12 +61,13 @@ const reportPerformance = () => {
 - [Largest Contentful Paint(LCP)](https://web.dev/lcp/)
 - [First Input Delay(FID)](https://web.dev/fid/)
 - [Time to First Byte(TTFB)](https://web.dev/ttfb/)
+- [Interaction to Next Paint(INP)](https://web.dev/inp/)
 
 ## Report params
 
 ```ts
 type ReportParams = {
-  metricsName: "CLS" | "LCP" | "FID" | "TTFB";
+  metricsName: "CLS" | "LCP" | "FID" | "TTFB" | "INP";
   metricsValue: number;
   // Get value from https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/effectiveType.
   networkType: string;

--- a/package.json
+++ b/package.json
@@ -26,20 +26,20 @@
   },
   "license": "MIT",
   "dependencies": {
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^3.0.0-beta.2"
   },
   "devDependencies": {
     "@types/jest": "^27.0.0",
-    "bundlesize": "^0.18.0",
-    "jest": "^27.0.0",
-    "ts-jest": "^27.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
+    "bundlesize": "^0.18.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.4",
-    "typescript": "^4.0.0",
+    "jest": "^27.0.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "ts-jest": "^27.0.0",
+    "typescript": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openameba/cwv-logger",
-  "version": "0.1.0",
+  "version": "0.1.1-beta.0",
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openameba/cwv-logger",
-  "version": "0.1.1-beta.0",
+  "version": "0.1.1-beta.1",
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export const SupportedMetrics = {
   CLS: "CLS",
   FID: "FID",
   TTFB: "TTFB",
+  INP: "INP",
 } as const;
 
 export type ReportParams = {

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -1,9 +1,9 @@
 import {
   FirstInputPolyfillEntry,
-  getCLS,
-  getFID,
-  getLCP,
-  getTTFB,
+  onCLS,
+  onFID,
+  onLCP,
+  onTTFB,
   onINP,
   ReportHandler as WebVitalsReportHandler,
   Metric as WebVitalsMetrics,
@@ -142,7 +142,7 @@ export const reportCLS: Report = (report) => {
       rectDiff,
     });
   };
-  getCLS(handleReportHandler(reportHandler));
+  onCLS(handleReportHandler(reportHandler));
 };
 
 export const reportLCP: Report = (report) => {
@@ -163,7 +163,7 @@ export const reportLCP: Report = (report) => {
       });
     });
   };
-  getLCP(handleReportHandler(reportHandler));
+  onLCP(handleReportHandler(reportHandler));
 };
 
 export const reportFID: Report = (report) => {
@@ -185,7 +185,7 @@ export const reportFID: Report = (report) => {
     });
   };
 
-  getFID(handleReportHandler(reportHandler));
+  onFID(handleReportHandler(reportHandler));
 };
 
 export const reportTTFB: Report = (report) => {
@@ -200,7 +200,7 @@ export const reportTTFB: Report = (report) => {
       networkType: getNetworkType(),
     });
   };
-  getTTFB(handleReportHandler(reportHandler));
+  onTTFB(handleReportHandler(reportHandler));
 };
 
 export const reportINP: Report<ReportOpts> = (report, option) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,10 +4036,10 @@ walker@^1.0.7:
   dependencies:
     makeerror "1.0.12"
 
-web-vitals@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.4.tgz#76563175a475a5e835264d373704f9dde718290c"
-  integrity sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==
+web-vitals@^3.0.0-beta.2:
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-3.0.0-beta.2.tgz#08c605295f36484256ee3acb5735b1f4dc9cd565"
+  integrity sha512-W9OALsWK4RkA5GWvLhsfszy+Q29WJBB27Dnucc3eYP6/0kz1XsfMgm+4au9X/KjXMIo92ZRU1fWBaSdNsaVjJg==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
INP(Interaction to Next Paint)の計測スクリプトを追加しました。

INPはFIDを拡張したもので、click, keypressなどのeventが発生してから次のpaint処理が走るまでの時間を計測します。
ユーザーのインタラクションから次のframeが表示されるまでに以下のように時間が計測されます。

> - The input delay, which is the time between when the user interacts with the page, and when event handlers execute.
> - The processing time, which is the total amount of time it takes to execute code in associated event handlers.
> - The presentation delay, which is the time between when event handlers have finished executing, and when the browser presents the next frame.

指標は以下のようになっています。

|Good|Needs Improvement|Poor|
|:-:|:-:|:-:|
|~ 200ms|200ms ~ 500ms|500ms ~|

[web-vitalsライブラリではINPに閾値を設定できて、defaultでは40ms以下はデータを取得しないようになっています。](https://github.com/GoogleChrome/web-vitals/pull/225)

詳細は https://web.dev/inp/ を確認してください。

INPはまだexperimentalな仕様なので今後変わる可能性があります。
そのためstableリリースではなく、`npm version prerelease --preid=beta`としてリリースします。
