### PR TITLE
feat: setup preid prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,10 @@ jobs:
         id: extract_branch
       - name: Check npm version preid
         run: |
-          HAS_PREID=$(node -p "'${{ steps.extract_branch.outputs.version }}'.startsWith('prerelease-') ? 1 : 0")
+          HAS_PREID=$(node -p "process.env.VERSION.startsWith('prerelease-') ? 1 : 0")
           echo "::set-output name=has_preid::${HAS_PREID}"
           if [ $HAS_PREID -eq 1 ]; then
-            PREID_NAME=$(node -p "const v = '${{ steps.extract_branch.outputs.version }}'.match(/^prerelease-(.+)$/); v ? v[1] : ''")
+            PREID_NAME=$(node -p "const v = process.env.VERSION.match(/^prerelease-(.+)$/); v ? v[1] : ''")
             # validate preid
             IS_ALLOWED=$(node -p "'${ALLOW_PREID}'.split('|').includes('${PREID_NAME}') ? 1 : 0")
             if [ $IS_ALLOWED -eq 0 ]; then
@@ -66,6 +66,8 @@ jobs:
             echo "::set-output name=name::${PREID_NAME}"
           fi
         id: preid
+        env:
+          VERSION: ${{ steps.extract_branch.outputs.version }}
       - name: Bump a package version
         if: steps.preid.outputs.has_preid == 0
         run: npm version ${{ steps.extract_branch.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
       - release/preminor
       - release/prepatch
       - release/prerelease
+      # Allow prerelease with preid
+      - release/prerelease-*
+
+env:
+  ALLOW_PREID: "beta|alpha"
 
 jobs:
   releaseing:
@@ -46,10 +51,37 @@ jobs:
           echo "::set-output name=name::${GITHUB_REF#refs/*/}"
           echo "::set-output name=version::${GITHUB_REF##*/}"
         id: extract_branch
+      - name: Check npm version preid
+        run: |
+          HAS_PREID=$(node -p "'${{ steps.extract_branch.outputs.version }}'.startsWith('prerelease-') ? 1 : 0")
+          echo "::set-output name=has_preid::${HAS_PREID}"
+          if [ $HAS_PREID -eq 1 ]; then
+            PREID_NAME=$(node -p "const v = '${{ steps.extract_branch.outputs.version }}'.match(/^prerelease-(.+)$/); v ? v[1] : ''")
+            # validate preid
+            IS_ALLOWED=$(node -p "'${ALLOW_PREID}'.split('|').includes('${PREID_NAME}') ? 1 : 0")
+            if [ $IS_ALLOWED -eq 0 ]; then
+              echo "`${PREID_NAME}` preid is not allowed."
+              exit 1
+            fi
+            echo "::set-output name=name::${PREID_NAME}"
+          fi
+        id: preid
       - name: Bump a package version
+        if: steps.preid.outputs.has_preid == 0
         run: npm version ${{ steps.extract_branch.outputs.version }}
+      - name: Bump a package version with preid
+        if: steps.preid.outputs.has_preid == 1
+        run: npm version prerelease --preid=${{ steps.preid.outputs.name }}
       - name: Releasing with npm
-        run: npm publish --access public
+        if: steps.preid.outputs.has_preid == 0
+        run: |
+          yarn build && yarn cp
+          npm publish --access public
+      - name: Releasing with npm tag
+        if: steps.preid.outputs.has_preid == 1
+        run: |
+          yarn build && yarn cp
+          npm publish --access public --tag=${{ steps.preid.outputs.name }}
       - name: Push version commit
         run: git push && git push --tags
       - name: Create Pull Request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,11 @@ jobs:
         run: |
           HAS_PREID=$(node -p "process.env.VERSION.startsWith('prerelease-') ? 1 : 0")
           echo "::set-output name=has_preid::${HAS_PREID}"
-          if [ $HAS_PREID -eq 1 ]; then
+          if [ "$HAS_PREID" -eq 1 ]; then
             PREID_NAME=$(node -p "const v = process.env.VERSION.match(/^prerelease-(.+)$/); v ? v[1] : ''")
             # validate preid
             IS_ALLOWED=$(node -p "'${ALLOW_PREID}'.split('|').includes('${PREID_NAME}') ? 1 : 0")
-            if [ $IS_ALLOWED -eq 0 ]; then
+            if [ "$IS_ALLOWED" -eq 0 ]; then
               echo "`${PREID_NAME}` preid is not allowed."
               exit 1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             if [[ "$PREID_NAME" =~ $ALLOW_PREID ]]; then
               echo "::set-output name=name::${PREID_NAME}"
             else
-              echo "`${PREID_NAME}` preid is not allowed."
+              echo "'${PREID_NAME}' preid is not allowed."
               exit 1
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,14 +56,14 @@ jobs:
           HAS_PREID=$(node -p "process.env.VERSION.startsWith('prerelease-') ? 1 : 0")
           echo "::set-output name=has_preid::${HAS_PREID}"
           if [ "$HAS_PREID" -eq 1 ]; then
-            PREID_NAME=$(node -p "const v = process.env.VERSION.match(/^prerelease-(.+)$/); v ? v[1] : ''")
+            PREID_NAME=${VERSION#prerelease-}
             # validate preid
-            IS_ALLOWED=$(node -p "'${ALLOW_PREID}'.split('|').includes('${PREID_NAME}') ? 1 : 0")
-            if [ "$IS_ALLOWED" -eq 0 ]; then
+            if [[ "$PREID_NAME" =~ $ALLOW_PREID ]]; then
+              echo "::set-output name=name::${PREID_NAME}"
+            else
               echo "`${PREID_NAME}` preid is not allowed."
               exit 1
             fi
-            echo "::set-output name=name::${PREID_NAME}"
           fi
         id: preid
         env:

--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ type ReportParams = {
   rectDiff?: string;
 };
 ```
+
+## リリースフロー
+
+[.github/workflows/release.yml](https://github.com/openameba/cwv-logger/blob/main/.github/workflows/release.yml)に合わせてバージョニングを指定してbranchを作成し、pushすると自動でリリースできます。
+
+`@openameba/cwv-logger@beta`のようにタグをつけてリリースしたい場合は[導入ガイド](https://github.com/openameba/cwv-logger/pull/8)を参考にリリース処理を行います。基本的には`release/prerelease-[PRE_ID]`というブランチをpushするとPRE_IDをもとに自動でタグつけされたバージョンでリリースされます。

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "run-s build:esm:js build:esm:rename",
     "build:esm:js": "tsc -p tsconfig.esm.json",
-    "build:esm:rename": "npx renamer --find js --replace mjs 'dist/**'",
-    "prepublishOnly": "yarn build && yarn cp"
+    "build:esm:rename": "npx renamer --find js --replace mjs 'dist/**'"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
[`web-vitals`ではINPを`next`としてタグつけ](https://github.com/GoogleChrome/web-vitals/tree/next)してリリースしているので、`cwv-logger`でも同じようにexperimentalな指標をタグつけしてリリースしていこうと考えています。

手動で都度リリース対応しても良いですが、Core Web Vitalsは仕様策定の進みが早いため今後もINPのようなexperimentalな指標が出てきてそれに合わせて実装を追加していくことが考えられるので、CIで自動化したいです。

そのため以下の方法で対応します。

- `release/prerelease-[PRE_ID]`ブランチにpushすると、PRE_IDに指定した値をタグとして取得し、自動でバージョニングとタグ付けをする
  - preid ... `npm version prerelease --preid [PRE_ID]`とすることで`v0.1.0-[PRE_ID].0` のようにバージョンにidを振ります
  - tag ... `npm publish --access public --tag [PRE_ID]`とすることで`pkg@[PRE_ID]` のようにパッケージ名にタグをつけることができます。(何も指定しない場合は`latest`タグがつきます)
- typoなどを防ぐために、PRE_IDは`beta or alpha`に絞り、必要に応じて増やします
- 運用ルールとして、PRE_IDに合わせたbranch名をbase branchとします。
  - 自動でPRが作成されるのでPRE_IDと同じ名前のbranchにマージします
