### PR TITLE
Feat/improve type infer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ type ReportParams = {
   networkType: string;
   // Currently not supported
   country?: string;
-  // Available with CLS, LCP and FID.
+  // Available with CLS, LCP, FID and INP.
   selectorName?: string;
   // Available only with CLS.
   rectDiff?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,32 @@ export const SupportedMetrics = {
   INP: "INP",
 } as const;
 
-export type ReportParams = {
-  metricsName: keyof typeof SupportedMetrics;
+type SharedReportParams<T extends keyof typeof SupportedMetrics> = {
+  metricsName: T;
   metricsValue: number;
   networkType: string;
   country?: string;
-  selectorName?: string;
-  rectDiff?: string;
 };
+
+type InteractiveMetricsReportParams = {
+  selectorName?: string;
+};
+
+type LCPReportParams = SharedReportParams<"LCP"> &
+  InteractiveMetricsReportParams;
+type FIDReportParams = SharedReportParams<"FID"> &
+  InteractiveMetricsReportParams;
+type INPReportParams = SharedReportParams<"INP"> &
+  InteractiveMetricsReportParams;
+type CLSReportParams = SharedReportParams<"CLS"> &
+  InteractiveMetricsReportParams & {
+    rectDiff?: string;
+  };
+type TTFBReportParams = SharedReportParams<"TTFB">;
+
+export type ReportParams =
+  | LCPReportParams
+  | FIDReportParams
+  | INPReportParams
+  | CLSReportParams
+  | TTFBReportParams;


### PR DESCRIPTION
型推論を改善してみました
現在の型だと各メトリクス固有のプロパティが同一のオブジェクトとして型定義されていましたが、メトリクスの種類によって型レベルでプロパティを絞れるようにしました。
これにより意図せずプロパティを指定しまうことを防ぐことができます

```ts
// Before: これまではどのメトリクスてあってもselectorNameにアクセスできた
params.selectorName

// After: 今後はmetricsNameで絞ることができるようになる
params.selectorName //これは型エラー
if(params.metricsName === "CLS") {
  params.selectorName; // これはOK
}
```