### PR TITLE
feat: do report attribution with FID and INP

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ type ReportParams = {
   country?: string;
   // Available with CLS, LCP, FID and INP.
   selectorName?: string;
+  // Available only with FID and INP.
+  eventTime?: string;
   // Available only with CLS.
   rectDiff?: string;
 };

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ type ReportParams = {
   selectorName?: string;
   // Available only with FID and INP.
   eventTime?: string;
+  // Available only with FID and INP.
+  // @see: https://github.com/GoogleChrome/web-vitals#loadstate
+  loadState?: 'loading' | 'dom-interactive' | 'dom-content-loaded' | 'complete';
   // Available only with CLS.
   rectDiff?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,9 +20,13 @@ type InteractiveMetricsReportParams = {
 export type LCPReportParams = SharedReportParams<"LCP"> &
   InteractiveMetricsReportParams;
 export type FIDReportParams = SharedReportParams<"FID"> &
-  InteractiveMetricsReportParams;
+  InteractiveMetricsReportParams & {
+    eventTime?: number;
+  };
 export type INPReportParams = SharedReportParams<"INP"> &
-  InteractiveMetricsReportParams;
+  InteractiveMetricsReportParams & {
+    eventTime?: number;
+  };
 export type CLSReportParams = SharedReportParams<"CLS"> &
   InteractiveMetricsReportParams & {
     rectDiff?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { LoadState } from "web-vitals";
+
 export const SupportedMetrics = {
   LCP: "LCP",
   CLS: "CLS",
@@ -22,10 +24,12 @@ export type LCPReportParams = SharedReportParams<"LCP"> &
 export type FIDReportParams = SharedReportParams<"FID"> &
   InteractiveMetricsReportParams & {
     eventTime?: number;
+    loadState?: LoadState;
   };
 export type INPReportParams = SharedReportParams<"INP"> &
   InteractiveMetricsReportParams & {
     eventTime?: number;
+    loadState?: LoadState;
   };
 export type CLSReportParams = SharedReportParams<"CLS"> &
   InteractiveMetricsReportParams & {

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -1,14 +1,16 @@
 import {
   FirstInputPolyfillEntry,
   onCLS,
-  onFID,
   onLCP,
   onTTFB,
-  onINP,
   ReportCallback as WebVitalsReportHandler,
   Metric as WebVitalsMetrics,
   ReportOpts,
+  FIDMetricWithAttribution,
+  INPMetricWithAttribution,
 } from "web-vitals";
+// NOTE: use attribution build to measure more details of performance event
+import { onFID, onINP } from "web-vitals/attribution";
 import { getElementName, getNetworkType } from "./base";
 import {
   CLSReportParams,
@@ -32,6 +34,7 @@ type LargestContentfulPaint = {
 type FirstInputDelay = {
   name: typeof SupportedMetrics.FID;
   entries: FirstInputPolyfillEntry[];
+  attribution: FIDMetricWithAttribution["attribution"];
 };
 
 const CLS_RECT_PROPERTIES = ["width", "height", "x", "y"] as const;
@@ -56,6 +59,7 @@ type TimeToFirstByte = {
 type InteractionToNextPaint = {
   name: typeof SupportedMetrics.INP;
   entries: FirstInputPolyfillEntry[];
+  attribution: INPMetricWithAttribution["attribution"];
 };
 
 type Metrics = BaseMetrics &
@@ -180,7 +184,7 @@ export const reportFID: Report<FIDReportParams> = (report) => {
       return;
     }
 
-    const { name, entries, delta } = metrics;
+    const { name, entries, delta, attribution } = metrics;
 
     entries.map((entry) => {
       const elementName = getElementName(entry.target);
@@ -189,6 +193,7 @@ export const reportFID: Report<FIDReportParams> = (report) => {
         metricsValue: delta,
         selectorName: elementName,
         networkType: getNetworkType(),
+        eventTime: attribution.eventTime,
       });
     });
   };
@@ -220,7 +225,7 @@ export const reportINP: Report<INPReportParams, ReportOpts> = (
       return;
     }
 
-    const { name, entries, delta } = metrics;
+    const { name, entries, delta, attribution } = metrics;
 
     entries.map((entry) => {
       const elementName = getElementName(entry.target);
@@ -229,6 +234,7 @@ export const reportINP: Report<INPReportParams, ReportOpts> = (
         metricsValue: delta,
         selectorName: elementName,
         networkType: getNetworkType(),
+        eventTime: attribution.eventTime,
       });
     });
   };

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -194,6 +194,7 @@ export const reportFID: Report<FIDReportParams> = (report) => {
         selectorName: elementName,
         networkType: getNetworkType(),
         eventTime: attribution.eventTime,
+        loadState: attribution.loadState,
       });
     });
   };
@@ -235,6 +236,7 @@ export const reportINP: Report<INPReportParams, ReportOpts> = (
         selectorName: elementName,
         networkType: getNetworkType(),
         eventTime: attribution.eventTime,
+        loadState: attribution.loadState,
       });
     });
   };


### PR DESCRIPTION
# 変更内容
`FID`と`INP`に関して、調査・改善のためのデータとしてパフォーマンスイベントの詳細を送るために、
`attribution`ビルドを利用して`eventTime`(`DOMHighResTimeStamp`)と`loadState`を送るようにしました

## 前提

下記関連リンクの`attribution`ビルドについての説明で、

> The "attribution" build is slightly larger than the "standard" build (by about 600 bytes, brotli'd), so while the code size is still small, it's only recommended if you're actually using these features.

とあるように、ビルドサイズに関わるため追加機能として必要になった場合にのみ、
こちらを利用することが推奨されています

今回の目的は原因調査が難しいFIDとINPの計測を改善することであるため、
この2つの指標に限った対応（`attribution`ビルドの利用）をしています

## 利用例

```ts
import("@openameba/cwv-logger").then(({ reportFID }) => {
  reportFID(({ metricsName, metricsValue, eventTime, loadState }) => {
    const startTime = Date.now();
    firebase
      .performance()
      .trace(metricsName)
      .record(startTime, metricsValue, { eventTime, loadState }); 
  });
// ...
```

# 関連リンク
- `attribution`ビルドについて：https://github.com/GoogleChrome/web-vitals#attribution-build
- ライブラリで取得できる各指標ごとの`attribution`：https://github.com/GoogleChrome/web-vitals#attribution